### PR TITLE
CheckboxがDOMツリーから消えたときにfelteのDataを保持

### DIFF
--- a/Checkbox.svelte
+++ b/Checkbox.svelte
@@ -19,7 +19,16 @@
 </script>
 
 <label class="root {klass}" class:disabled class:full-width={fullWidth} style:--url={`url('${checkBoldIcon}')`}>
-  <input type="checkbox" class="checkbox" {style} {value} {name} {disabled} bind:checked />
+  <input
+    type="checkbox"
+    class="checkbox"
+    {style}
+    {value}
+    {name}
+    {disabled}
+    bind:checked
+    data-felte-keep-on-remove="true"
+  />
   <div>
     <slot />
   </div>


### PR DESCRIPTION
### 作業内容

- Checkbox.svelteにdata-felte-keep-on-remove=trueを追加

----------

### 作成・修正後

https://user-images.githubusercontent.com/82352253/202113436-40bcdb87-51b8-4a16-a88d-a316f024d25f.mov

--------
### 確認したいこと

- 現在data-felte-keep-on-remove=trueの固定値になっていますが、Propsを作成した方がいいでしょうか。

