### PR TITLE
SingleSelectToggleButtonsにonChangeを指定できるようにする。

### DIFF
--- a/SingleSelectToggleButtons.svelte
+++ b/SingleSelectToggleButtons.svelte
@@ -12,6 +12,7 @@
   /** Felteのerrorsオブジェクト。正しい型を書くのが難しい割にメリットが乏しいのでanyを使っている */
   export let errors: Readable<any> | undefined = undefined
   export let style: string | undefined = undefined
+  export let onChangeSelected: (selected: Value | undefined) => void = () => {}
   let klass = ''
   export { klass as class }
 
@@ -25,7 +26,14 @@
 
 <div class={`root ${klass}`} {style} {...$$restProps}>
   {#each values as value (value)}
-    <button class:selected={value === selected} type="button" on:click={() => (selected = value)}>
+    <button
+      class:selected={value === selected}
+      type="button"
+      on:click={() => {
+        selected = value
+        onChangeSelected(selected)
+      }}
+    >
       {titles[value] ?? value}
     </button>
   {/each}


### PR DESCRIPTION
※このPRと関連するURLがあれば書いてください。  
以下の先行PR
https://linear.app/subscline/issue/SUB-596/チャットステータスをトグルボタンで更新できるようにする

### 作業内容

- SingleSelectToggleButtonsにonChangeを指定できるようにする。

### 動作確認
 - web/serc/pages/catalog/SingleSelectButtons-component.svelteに以下を追記
 ``` svelte
<SectionTitle>onChangeSelectedを設定</SectionTitle>
<Sample
  code={`<SingleSelectToggleButtons values={['S', 'M', 'L']} onChangeSelected={(selected) => { alert(selected) }/>
`}
>
  <SingleSelectToggleButtons
    values={['S', 'M', 'L']}
    onChangeSelected={(selected) => {
      alert(selected)
    }}
  />
</Sample>
```

----------

### 作成・修正後
![image](https://github.com/on-team/shared-components/assets/25718325/adda4b68-208c-410b-90a0-dcff7a7fab31)

※このPRで作成・修正した部分のスクショや動画などを添付してください（リファクタリングなど見た目に変化がない場合は不要）
