### PR TITLE
DataTableソート状態のURLパラメータ反映不具合修正

### DIFF
--- a/DataTable.svelte
+++ b/DataTable.svelte
@@ -3,7 +3,10 @@
     | string
     | { id: string; title?: string; sortable?: boolean; width?: string; align?: 'left' | 'center' | 'right' }
 
-  export type SortingState = { columnId: string; reversed: boolean }
+  export type SortDirection = 'asc' | 'desc' | 'none';
+
+  export type SortingState = { columnId: string; direction: SortDirection; reversed: boolean }
+
 </script>
 
 <script lang="ts">
@@ -152,14 +155,15 @@
 
   async function onClickSortButton(columnId: string) {
     if (sortingState?.columnId === columnId) {
-      await onChangeSortingState?.({ columnId, reversed: !sortingState.reversed })
+      const newReversed = !sortingState.reversed;
+      await onChangeSortingState?.({ columnId, direction: sortingState.direction, reversed: newReversed })
       if (!isBackendPagination) {
         sortingState.reversed = !sortingState.reversed
       }
     } else {
-      await onChangeSortingState?.({ columnId, reversed: false })
+      await onChangeSortingState?.({ columnId, direction: 'asc', reversed: false })
       if (!isBackendPagination) {
-        sortingState = { columnId, reversed: false }
+        sortingState = { columnId, direction: 'asc', reversed: false  }
       }
     }
   }

--- a/Select.svelte
+++ b/Select.svelte
@@ -20,6 +20,7 @@
   export let errors: Readable<any> | undefined = undefined
   export let disabled: boolean = false
   export let fullWidth = false
+  export let fontSize: string | undefined = '1em'
   export let withClearButton = false
   export let onChangeSelected: ((selected: T | undefined) => void) | undefined = undefined
   export let style: string | undefined = undefined
@@ -97,6 +98,7 @@
   class:disabled
   class:opened={dropdownInfo !== undefined}
   class:full-width={fullWidth}
+  style:font-size={fontSize}
   {style}
   type="button"
   {disabled}
@@ -152,6 +154,7 @@
         style:--dropdown-anchor={`${dropdownInfo.anchorPx}px`}
         style:--dropdown-width={`${dropdownInfo.widthPx}px`}
         style:--dropdown-man-height={`${dropdownInfo.maxHeightPx}px`}
+        style:font-size={fontSize}
         use:lockBodyScroll
       >
         {#each values as value, i}

--- a/Select.svelte
+++ b/Select.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import _ from 'lodash'
   import { Readable } from 'svelte/store'
-  import chevronBottom from './chevron-bottom.svg'
-  import closeCircleIcon from './close-circle.svg'
   import CommonCss from './CommonCss.svelte'
   import Divider from './Divider.svelte'
   import Icon from './Icon.svelte'
   import IconButton from './IconButton.svelte'
   import Portal from './Portal.svelte'
+  import chevronBottom from './chevron-bottom.svg'
+  import closeCircleIcon from './close-circle.svg'
   import { isNestedClickEvent, lockBodyScroll } from './utils'
 
   type T = $$Generic<string>
@@ -23,6 +23,7 @@
   export let withClearButton = false
   export let onChangeSelected: ((selected: T | undefined) => void) | undefined = undefined
   export let style: string | undefined = undefined
+  export let reverse: boolean = false
   let klass = ''
   export { klass as class }
 
@@ -42,7 +43,7 @@
     onChangeSelected?.(newSelected)
   }
 
-  type DropdownInfo = { leftPx: number; topPx: number; widthPx: number; maxHeightPx: number }
+  type DropdownInfo = { leftPx: number; anchorPx: number; widthPx: number; maxHeightPx: number }
   let dropdownInfo: DropdownInfo | undefined = undefined
 
   function onClickLauncher(event: MouseEvent) {
@@ -50,11 +51,21 @@
 
     if (event.currentTarget instanceof HTMLElement) {
       const rect = event.currentTarget.getBoundingClientRect()
-      dropdownInfo = {
-        leftPx: rect.left,
-        topPx: rect.bottom,
-        widthPx: rect.width,
-        maxHeightPx: window.innerHeight - rect.bottom,
+
+      if (!reverse) {
+        dropdownInfo = {
+          leftPx: rect.left,
+          anchorPx: rect.bottom,
+          widthPx: rect.width,
+          maxHeightPx: window.innerHeight - rect.bottom,
+        }
+      } else {
+        dropdownInfo = {
+          leftPx: rect.left,
+          anchorPx: window.innerHeight - rect.top,
+          widthPx: rect.width,
+          maxHeightPx: rect.top,
+        }
       }
     }
   }
@@ -136,8 +147,9 @@
     <div class="backdrop" use:setupBackdrop>
       <div
         class="dropdown"
+        class:reverse
         style:--dropdown-left={`${dropdownInfo.leftPx}px`}
-        style:--dropdown-top={`${dropdownInfo.topPx}px`}
+        style:--dropdown-anchor={`${dropdownInfo.anchorPx}px`}
         style:--dropdown-width={`${dropdownInfo.widthPx}px`}
         style:--dropdown-man-height={`${dropdownInfo.maxHeightPx}px`}
         use:lockBodyScroll
@@ -240,7 +252,7 @@
   .dropdown {
     position: fixed;
     left: var(--dropdown-left);
-    top: var(--dropdown-top);
+    top: var(--dropdown-anchor);
     box-sizing: border-box;
     width: var(--dropdown-width);
     max-height: var(--dropdown-man-height);
@@ -249,6 +261,11 @@
     box-shadow: 0 3px 14px hsla(0, 0%, 0%, 20%);
 
     overflow: auto;
+  }
+
+  .dropdown.reverse {
+    top: initial;
+    bottom: var(--dropdown-anchor);
   }
 
   .option {


### PR DESCRIPTION
fix SUB-862
## 不具合内容
DataTableのソート方向を示す`direction`の設定が無いため、URLパラメータ`Direction`に`undefined`が表示します。
これが原因で、ユーザーが設定した正常なソート状態を保持出来ませんでした。

## 修正内容
- `DataTable.svelte`の`sortingState`を改善し、ソート方向（`'asc'`、`'desc'`、`'none'`）が適切に`sortingState`に設定されるようにしました。
- `sortDirection`を更新し、`undefined`が設定される問題を解決しました。この`sortDirection`をexportすることで、親が型を受け取れるようにしました。

## 期待される結果
`sortable`カラムを含む全ての画面で、ユーザーがソート状態を画面リロードや他画面からの復帰を実行しました。
その時、正しいURLパラメータが保持されるようになりました。

## 検証方法
`sortable`カラムが含まれる箇所でソートを行い、画面リロードおよび画面遷移を行った後、ソート状態が正しくURLパラメータに反映されることを手動で検証し確認しました。

## 影響範囲
`sortable`カラムを使用している全ての画面に影響しますが、今後`sortable`カラムを持つ全てのpageを修正します。

## スクリーンショット
改善前の表示
![新規メモ](https://github.com/on-team/shared-components/assets/96866048/f12311d2-9d36-4b94-b0be-88dad64c8045)
改善後の表示
![新規メモ1](https://github.com/on-team/shared-components/assets/96866048/3f4c78ed-87f3-4447-bacc-9afb22df4896)
