### PR TITLE
DataTableソート状態のURLパラメータ反映不具合修正

### DIFF
--- a/DataTable.svelte
+++ b/DataTable.svelte
@@ -3,7 +3,10 @@
     | string
     | { id: string; title?: string; sortable?: boolean; width?: string; align?: 'left' | 'center' | 'right' }
 
-  export type SortingState = { columnId: string; reversed: boolean }
+  export type SortDirection = 'asc' | 'desc' | 'none';
+
+  export type SortingState = { columnId: string; direction: SortDirection; reversed: boolean }
+
 </script>
 
 <script lang="ts">
@@ -152,14 +155,15 @@
 
   async function onClickSortButton(columnId: string) {
     if (sortingState?.columnId === columnId) {
-      await onChangeSortingState?.({ columnId, reversed: !sortingState.reversed })
+      const newReversed = !sortingState.reversed;
+      await onChangeSortingState?.({ columnId, direction: sortingState.direction, reversed: newReversed })
       if (!isBackendPagination) {
         sortingState.reversed = !sortingState.reversed
       }
     } else {
-      await onChangeSortingState?.({ columnId, reversed: false })
+      await onChangeSortingState?.({ columnId, direction: 'asc', reversed: false })
       if (!isBackendPagination) {
-        sortingState = { columnId, reversed: false }
+        sortingState = { columnId, direction: 'asc', reversed: false  }
       }
     }
   }


### PR DESCRIPTION
対応ISSUE: https://linear.app/subscline/issue/SUB-862/datatableのソート状態をurlパラメータを正しく保持する機能の改善fix SUB-862
## 不具合内容
DataTableのソート方向を示す`direction`の設定が無いため、URLパラメータ`Direction`に`undefined`が表示します。
これが原因で、ユーザーが設定した正常なソート状態を保持出来ませんでした。

## 修正内容
- `DataTable.svelte`の`sortingState`を改善し、ソート方向（`'asc'`、`'desc'`、`'none'`）が適切に`sortingState`に設定されるようにしました。
- `sortDirection`を更新し、`undefined`が設定される問題を解決しました。この`sortDirection`をexportすることで、親が型を受け取れるようにしました。

## 期待される結果
`sortable`カラムを含む全ての画面で、ユーザーがソート状態を画面リロードや他画面からの復帰を実行しました。
その時、正しいURLパラメータが保持されるようになりました。

## 検証方法
`sortable`カラムが含まれる箇所でソートを行い、画面リロードおよび画面遷移を行った後、ソート状態が正しくURLパラメータに反映されることを手動で検証し確認しました。

## 影響範囲
`sortable`カラムを使用している全ての画面に影響しますが、今後`sortable`カラムを持つ全てのpageを修正します。

## スクリーンショット
改善前の表示
![新規メモ](https://github.com/on-team/shared-components/assets/96866048/f8a8c6ce-34bc-4d5a-b84e-9d07ee4a1e21)

改善後の表示
![新規メモ1](https://github.com/on-team/shared-components/assets/96866048/9fd6c209-bac7-404c-bdb2-626bc97ee616)
